### PR TITLE
Add robots.txt and enrich sitemap with lastmod + exclusions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,18 +3,16 @@ import react from '@astrojs/react';
 import vercel from '@astrojs/vercel';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
-import { loadEnv } from 'vite';
-
-const { DATOCMS_API_TOKEN } = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
 
 async function fetchDato(query) {
-  if (!DATOCMS_API_TOKEN) return null;
+  const token = process.env.DATOCMS_API_TOKEN;
+  if (!token) return null;
   try {
     const res = await fetch('https://graphql.datocms.com', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${DATOCMS_API_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ query }),
     });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,40 @@ import react from '@astrojs/react';
 import vercel from '@astrojs/vercel';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
+import { loadEnv } from 'vite';
+
+const { DATOCMS_API_TOKEN } = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
+
+async function fetchDato(query) {
+  if (!DATOCMS_API_TOKEN) return null;
+  try {
+    const res = await fetch('https://graphql.datocms.com', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${DATOCMS_API_TOKEN}`,
+      },
+      body: JSON.stringify({ query }),
+    });
+    const json = await res.json();
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const articleDates = new Map();
+const projectDates = new Map();
+
+const articlesData = await fetchDato(`query { allArticles { slug date } }`);
+for (const a of articlesData?.allArticles ?? []) {
+  if (a.slug && a.date) articleDates.set(`/blog/${a.slug}`, a.date);
+}
+
+const projectsData = await fetchDato(`query { allProjects { slug date } }`);
+for (const p of projectsData?.allProjects ?? []) {
+  if (p.slug && p.date) projectDates.set(`/work/${p.slug}`, p.date);
+}
 
 export default defineConfig({
   site: 'https://adithyabhat.com',
@@ -13,7 +47,15 @@ export default defineConfig({
   }),
   integrations: [
     react(),
-    sitemap(),
+    sitemap({
+      filter: (page) => !page.includes('/404') && !page.includes('/legal'),
+      serialize(item) {
+        const path = new URL(item.url).pathname.replace(/\/$/, '');
+        const lastmod = articleDates.get(path) ?? projectDates.get(path);
+        if (lastmod) item.lastmod = new Date(lastmod).toISOString();
+        return item;
+      },
+    }),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://adithyabhat.com/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Add `public/robots.txt` so crawlers can discover the existing sitemap at `https://adithyabhat.com/sitemap-index.xml`
- Filter `/404` and `/legal` out of the generated sitemap (neither belongs in search results)
- Inject `<lastmod>` for every `/blog/[slug]` and `/work/[slug]` entry by reading the `date` field from DatoCMS at build time

## Why

`@astrojs/sitemap` was already producing a sitemap on every build, but search engines had no `robots.txt` pointing to it, the index was polluted with `/404` and `/legal`, and there were no freshness hints — so Google had no reason to re-crawl updated content. These three small changes make the sitemap discoverable, clean, and informative.

## Implementation notes

- Uses `loadEnv` from Vite so `DATOCMS_API_TOKEN` resolves the same way it does in app code (works locally and on Vercel)
- The DatoCMS fetch is wrapped in try/catch returning `null` — if Dato is unreachable during build, the sitemap still generates (just without `lastmod`) rather than failing the build
- API routes (`/api/contact`) are already excluded by `@astrojs/sitemap` automatically — no extra filter needed

## Test plan

- [ ] Confirm Vercel preview build succeeds
- [ ] Open `https://<preview-url>/sitemap-index.xml` and `https://<preview-url>/sitemap-0.xml` — verify all blog/work URLs are present, `/404` and `/legal` are absent, and `<lastmod>` is populated
- [ ] Open `https://<preview-url>/robots.txt` — verify the `Sitemap:` line is correct
- [ ] After merge to production: submit `https://adithyabhat.com/sitemap-index.xml` in Google Search Console