### PR TITLE
fix: align page content with navbar and remove hero load flash

### DIFF
--- a/src/components/astro/Hero.astro
+++ b/src/components/astro/Hero.astro
@@ -429,6 +429,24 @@ import HeroAside from './HeroAside.astro';
       }
     }
 
+    /* ===== STAGGERED REVEAL ===== */
+    /* Hide reveal targets up-front on hover-capable, motion-allowed devices
+       so the JS-driven stagger doesn't flash visible content first. */
+    @media (hover: hover) and (prefers-reduced-motion: no-preference) {
+      [data-hero-reveal] {
+        opacity: 0;
+        transform: translateY(16px);
+        transition:
+          opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+          transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+
+      [data-hero-reveal].is-revealed {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
     /* ===== REDUCED MOTION ===== */
     @media (prefers-reduced-motion: reduce) {
       .shape { animation: none; }
@@ -447,19 +465,13 @@ import HeroAside from './HeroAside.astro';
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const hasHover = window.matchMedia('(hover: hover)').matches;
 
-    // Staggered entrance — JS-driven, only on desktop (mobile renders immediately)
+    // Staggered entrance — JS-driven, only on desktop (mobile renders immediately).
+    // Initial hidden state lives in CSS so nothing paints visible before the stagger runs.
     if (!prefersReducedMotion && hasHover) {
       const reveals = hero.querySelectorAll<HTMLElement>('[data-hero-reveal]');
-      reveals.forEach((el) => {
-        el.style.opacity = '0';
-        el.style.transform = 'translateY(16px)';
-      });
-
       reveals.forEach((el, i) => {
         setTimeout(() => {
-          el.style.transition = 'opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1)';
-          el.style.opacity = '1';
-          el.style.transform = 'translateY(0)';
+          el.classList.add('is-revealed');
         }, 100 + i * 100);
       });
     }

--- a/src/components/astro/Navbar.astro
+++ b/src/components/astro/Navbar.astro
@@ -8,8 +8,6 @@ const routes = [
 ];
 
 const currentPath = Astro.url.pathname;
-const isPhotosPage = currentPath === '/photos';
-const padding = isPhotosPage ? 'px-6 md:px-16' : 'px-6 md:px-12 lg:px-20 xl:px-32';
 
 function isActive(link: string): boolean {
   if (link === '/') return currentPath === '/';
@@ -18,10 +16,7 @@ function isActive(link: string): boolean {
 ---
 
 <nav class="navbar sticky w-full top-0 z-50">
-  <div class:list={[
-    'navbar-inner flex items-center justify-between py-4 md:py-5 max-w-[1400px] mx-auto',
-    padding
-  ]}>
+  <div class="navbar-inner flex items-center justify-between py-4 md:py-5 max-w-[1400px] mx-auto px-6 md:px-12 lg:px-20 xl:px-32">
     <div class="flex items-center gap-3">
       <a href="/" class="nav-brand group flex items-center gap-3">
         <img

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -82,8 +82,6 @@ import FloatingShapes from '@/components/astro/FloatingShapes.astro';
     grid-template-columns: 1fr;
     gap: 3rem;
     align-items: start;
-    max-width: 1100px;
-    margin: 0 auto;
   }
 
   @media (min-width: 900px) {

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@/layouts/PageLayout.astro';
+import Container from '@/components/astro/Container.astro';
 import PhotoGallery from '@/components/react/PhotoGallery';
 import FloatingShapes from '@/components/astro/FloatingShapes.astro';
 import { fetchGalleryAPI } from '@/lib/datocms';
@@ -16,7 +17,7 @@ const cameras = [...new Set(places.map((p: any) => p.camera).filter(Boolean))];
 ---
 
 <PageLayout title="Photos | Adithya NR">
-  <div class="photos-page">
+  <Container class="relative pb-16 md:pb-24">
     <FloatingShapes />
 
     <!-- Hero header -->
@@ -71,23 +72,10 @@ const cameras = [...new Set(places.map((p: any) => p.camera).filter(Boolean))];
     <div class="photos-gallery">
       <PhotoGallery places={places} client:load />
     </div>
-  </div>
+  </Container>
 </PageLayout>
 
 <style>
-  .photos-page {
-    position: relative;
-    padding: 0 1.5rem 4rem;
-    max-width: 1400px;
-    margin: 0 auto;
-  }
-
-  @media (min-width: 768px) {
-    .photos-page {
-      padding: 0 4rem 6rem;
-    }
-  }
-
   /* ===== HEADER ===== */
   .photos-header {
     position: relative;


### PR DESCRIPTION
## Summary
- **Navbar**: replaced the brittle `isPhotosPage` conditional (which silently fell back to wider padding when the URL had a trailing slash) with one consistent padding scheme on every route.
- **Photos**: routed the page through the shared `Container` so its left/right padding matches the navbar, and collapsed the now-redundant `.photos-page` wrapper.
- **Contact**: removed `.contact-grid`'s own `max-width: 1100px; margin: 0 auto`, which was re-centering the grid inside `Container` and pulling it inward of the navbar.
- **Hero**: moved the `data-hero-reveal` hidden state into a CSS media query so reveal targets are never painted visible before the JS stagger runs — fixes the "loads, snaps, then animates" flash on first paint.

## Test plan
- [ ] `/photos`: navbar logo and "Gallery" eyebrow share the same left edge at every breakpoint (desktop xl, lg, md, mobile).
- [ ] `/contact`: navbar logo and the "Contact" eyebrow share the same left edge; two-column grid spans the full Container width above 900px.
- [ ] `/`: hero loads with content already in its hidden state, then staggers in — no visible "snap to invisible" between paint and animation.
- [ ] Mobile (`hover: none`) and `prefers-reduced-motion: reduce` paths: hero renders immediately with no transitions.
- [ ] Photo grid still has appropriate bottom spacing.
- [ ] Other pages (`/`, `/about`, `/work`, `/blog`, `/uses`, `/legal`) are unaffected — they already used the navbar's default padding scheme.