### PR TITLE
Rework palette to KTM orange, de-template UI, clean up dead code

### DIFF
--- a/src/components/astro/Card.astro
+++ b/src/components/astro/Card.astro
@@ -11,14 +11,12 @@ interface Props {
   type: 'article' | 'project';
   external?: boolean;
   transitionName?: string;
-  index?: number;
 }
 
-const { title, href, thumbnail, date, tags, type, external = false, transitionName, index = 0 } = Astro.props;
+const { title, href, thumbnail, date, tags, type, external = false, transitionName } = Astro.props;
 
 const formattedDate = (type === 'article' && date) ? dayjs(date as string).format('MMM YYYY') : '';
 const tagList = tags ? tags.split(/[,·]/).map(t => t.trim()).filter(Boolean) : [];
-const indexLabel = String(index + 1).padStart(2, '0');
 ---
 
 <a
@@ -40,7 +38,6 @@ const indexLabel = String(index + 1).padStart(2, '0');
         class="card-img"
         style={thumbnail.responsiveImage.base64 ? `background-image: url(${thumbnail.responsiveImage.base64}); background-size: cover;` : ''}
       />
-      <span class="card-index" aria-hidden="true">{indexLabel}</span>
     </div>
   )}
 
@@ -136,31 +133,6 @@ const indexLabel = String(index + 1).padStart(2, '0');
 
   .card:hover .card-img {
     transform: scale(1.07);
-  }
-
-  /* Decorative index number on image */
-  .card-index {
-    position: absolute;
-    bottom: 0.625rem;
-    right: 0.875rem;
-    font-family: 'Bricolage Grotesque', Georgia, serif;
-    font-size: 3.5rem;
-    font-weight: 800;
-    line-height: 1;
-    color: white;
-    opacity: 0;
-    transform: translateY(8px);
-    transition:
-      opacity 0.4s ease,
-      transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
-    pointer-events: none;
-    text-shadow: 0 2px 16px rgba(0, 0, 0, 0.5);
-    z-index: 2;
-  }
-
-  .card:hover .card-index {
-    opacity: 0.3;
-    transform: translateY(0);
   }
 
   /* ===== Content ===== */
@@ -293,10 +265,6 @@ const indexLabel = String(index + 1).padStart(2, '0');
       transform: none;
     }
 
-    .card:hover .card-index {
-      opacity: 0;
-    }
-
     .card:active {
       transform: scale(0.98);
       transition-duration: 0.1s;
@@ -319,7 +287,6 @@ const indexLabel = String(index + 1).padStart(2, '0');
   @media (prefers-reduced-motion: reduce) {
     .card,
     .card-img,
-    .card-index,
     .card-arrow,
     .card-tag,
     .card-accent-bar,

--- a/src/components/astro/CardGrid.astro
+++ b/src/components/astro/CardGrid.astro
@@ -18,7 +18,7 @@ const pathname = type === 'article' ? 'blog' : 'work';
 ---
 
 <div class:list={['grid gap-9 mt-8', gridCols]} data-animate-stagger>
-  {items.map((item, i) => {
+  {items.map((item) => {
     const href = (item as Article).externalLink
       ? (item as Article).externalLink!
       : `/${pathname}/${item.slug}`;
@@ -35,7 +35,6 @@ const pathname = type === 'article' ? 'blog' : 'work';
           type={type}
           external={external}
           transitionName={`card-${item.slug}`}
-          index={i}
         />
       </div>
     );

--- a/src/components/astro/Eyebrow.astro
+++ b/src/components/astro/Eyebrow.astro
@@ -1,14 +1,11 @@
 ---
 interface Props {
-  /** When true, renders the leading orange dash mark. */
-  dash?: boolean;
   class?: string;
 }
-const { dash = true, class: className = '' } = Astro.props;
+const { class: className = '' } = Astro.props;
 ---
 
 <span class:list={['eyebrow', className]}>
-  {dash && <span class="eyebrow-dash" aria-hidden="true"></span>}
   <slot />
 </span>
 
@@ -16,19 +13,11 @@ const { dash = true, class: className = '' } = Astro.props;
   .eyebrow {
     display: inline-flex;
     align-items: center;
-    gap: 0.625rem;
     font-family: 'Space Grotesk', sans-serif;
     font-size: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--accent);
-  }
-
-  .eyebrow-dash {
-    display: inline-block;
-    width: 1.5rem;
-    height: 2px;
-    background: var(--accent);
   }
 </style>

--- a/src/components/astro/Navbar.astro
+++ b/src/components/astro/Navbar.astro
@@ -146,9 +146,29 @@ function isActive(link: string): boolean {
 
 <style>
   .navbar {
+    transition: box-shadow 0.4s ease;
+  }
+
+  /* Blurred background lives on its own layer that is invisible at the top of
+     the page — so the hero's ambient light flows through with nothing to seam
+     against — and fades in only once scrolled, where a defined sticky header
+     is expected. (A blurred bar can't fade at an edge without showing a line,
+     so we toggle the whole layer instead of masking it.) */
+  .navbar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
     background: var(--nav-bg);
-    border-bottom: 1px solid var(--nav-border);
-    transition: border-color 0.4s ease, box-shadow 0.4s ease;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Blur is gated on the scrolled state too, so no backdrop surface is
+     composited while the layer is invisible at the top of the page. */
+  .navbar.is-scrolled::after {
+    opacity: 1;
     -webkit-backdrop-filter: saturate(180%) blur(20px);
     backdrop-filter: saturate(180%) blur(20px);
   }
@@ -164,7 +184,7 @@ function isActive(link: string): boolean {
       transparent 40%
     );
     pointer-events: none;
-    z-index: 0;
+    z-index: 1;
     opacity: 0;
     transition: opacity 0.5s ease;
   }
@@ -179,13 +199,12 @@ function isActive(link: string): boolean {
 
   .navbar-inner {
     position: relative;
-    z-index: 1;
+    z-index: 2;
   }
 
   /* Scrolled state */
   .navbar.is-scrolled {
     box-shadow: 0 4px 24px -8px rgba(0, 0, 0, 0.2);
-    border-bottom-color: color-mix(in srgb, var(--accent) 12%, var(--nav-border));
   }
 
   /* Logo hover */
@@ -320,7 +339,7 @@ function isActive(link: string): boolean {
     width: 300px;
     height: 300px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(249, 115, 22, 0.15) 0%, rgba(249, 115, 22, 0.04) 50%, transparent 70%);
+    background: radial-gradient(circle, rgba(var(--accent-glow-rgb), 0.15) 0%, rgba(var(--accent-glow-rgb), 0.04) 50%, transparent 70%);
     top: -60px;
     right: -80px;
     pointer-events: none;
@@ -354,7 +373,7 @@ function isActive(link: string): boolean {
   }
 
   :global([data-theme="light"]) .menu-orb {
-    background: radial-gradient(circle, rgba(249, 115, 22, 0.12) 0%, rgba(249, 115, 22, 0.03) 50%, transparent 70%);
+    background: radial-gradient(circle, rgba(var(--accent-glow-rgb), 0.12) 0%, rgba(var(--accent-glow-rgb), 0.03) 50%, transparent 70%);
   }
 
   /* ===== DECORATIVE RING ===== */

--- a/src/components/astro/ProjectShowcase.astro
+++ b/src/components/astro/ProjectShowcase.astro
@@ -15,7 +15,6 @@ const { projects } = Astro.props;
     const img = project.thumbnail?.responsiveImage;
     const tagList = project.tags ? project.tags.split(/[,·]/).map(t => t.trim()).filter(Boolean) : [];
     const href = `/work/${project.slug}`;
-    const indexLabel = String(i + 1).padStart(2, '0');
     const isEven = i % 2 === 1;
     const year = project.date ? dayjs(project.date as string).format('YYYY') : '';
 
@@ -49,7 +48,6 @@ const { projects } = Astro.props;
 
             {/* Info side */}
             <div class="pw-project-info">
-              <span class="pw-project-num" aria-hidden="true">{indexLabel}</span>
               <h3 class="pw-project-title">{project.title}</h3>
               {tagList.length > 0 && (
                 <div class="pw-project-tags">
@@ -160,25 +158,6 @@ const { projects } = Astro.props;
     gap: 0;
   }
 
-  .pw-project-num {
-    font-family: 'Bricolage Grotesque', Georgia, serif;
-    font-size: clamp(4rem, 8vw, 6.5rem);
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: -0.04em;
-    color: var(--border);
-    transition: color 0.4s ease;
-    margin-bottom: 0.75rem;
-  }
-
-  .pw-project:hover .pw-project-num {
-    color: var(--accent-glow-strong);
-  }
-
-  [data-theme="light"] .pw-project:hover .pw-project-num {
-    color: color-mix(in srgb, var(--accent) 20%, transparent);
-  }
-
   .pw-project-title {
     font-family: 'Bricolage Grotesque', Georgia, serif;
     font-size: clamp(1.5rem, 3vw, 2.25rem);
@@ -280,10 +259,6 @@ const { projects } = Astro.props;
       gap: 1.25rem;
     }
 
-    .pw-project-num {
-      font-size: 3rem;
-      margin-bottom: 0.25rem;
-    }
   }
 
   /* ===== TOUCH ===== */
@@ -298,10 +273,6 @@ const { projects } = Astro.props;
 
     .pw-project:hover .pw-project-title {
       color: var(--text);
-    }
-
-    .pw-project:hover .pw-project-num {
-      color: var(--border);
     }
 
     .pw-project:active {
@@ -324,7 +295,6 @@ const { projects } = Astro.props;
     .pw-project-img,
     .pw-project-accent,
     .pw-project-cta-arrow,
-    .pw-project-num,
     .pw-project-title,
     .pw-project-tag,
     .pw-project-cta,

--- a/src/components/astro/Testimonials.astro
+++ b/src/components/astro/Testimonials.astro
@@ -6,7 +6,7 @@ const row1Cards = [
     role: 'Head of AI & Design Engineering',
     company: 'Fluence',
     emoji: '🎨',
-    accent: '249, 115, 22',
+    accent: '255, 102, 0',
   },
   {
     quote: "One of the finest and most creative UI Developers I've interacted with. He has the acumen to recreate your designs flawlessly and suggest improvements.",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -62,7 +62,7 @@ const practiceColumns = [
   },
   {
     title: 'Tools',
-    desc: 'Day-one installs on every new laptop — the kind that save me an hour every day.',
+    desc: 'The first things I install on a new laptop. Each one saves me an hour a day.',
     skills: [
       { label: 'Figma', meta: 'daily' },
       { label: 'VS Code, Cursor', meta: 'daily' },
@@ -115,8 +115,8 @@ const practiceColumns = [
           <div class="about-aside-block">
             <Eyebrow>Outside the screen</Eyebrow>
             <p class="about-aside-text">
-              When I'm not near a keyboard, you'll usually find me on a motorcycle —
-              long road days, weekend offroad trails, or out chasing a good coffee
+              When I'm not near a keyboard, you'll usually find me on a motorcycle.
+              Long road days, weekend offroad trails, or out chasing a good coffee
               spot. Riding is my reset button between hard problems.
             </p>
           </div>
@@ -564,7 +564,6 @@ const practiceColumns = [
             <article class="practice-col" data-animate style={`--stagger-index: ${i}`}>
               <div class="practice-col-head">
                 <h3 class="practice-col-title">{col.title}</h3>
-                <span class="practice-col-num">{String(i + 1).padStart(2, '0')}</span>
               </div>
               <p class="practice-col-desc">{col.desc}</p>
               <ul class="practice-col-list">
@@ -625,10 +624,6 @@ const practiceColumns = [
         }
 
         .practice-col-head {
-          display: flex;
-          align-items: baseline;
-          justify-content: space-between;
-          gap: 1rem;
           margin-bottom: 0.6rem;
         }
 
@@ -639,13 +634,6 @@ const practiceColumns = [
           letter-spacing: -0.02em;
           color: var(--accent);
           margin: 0;
-        }
-
-        .practice-col-num {
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 0.7rem;
-          color: var(--text-muted);
-          letter-spacing: 0.04em;
         }
 
         .practice-col-desc {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -23,8 +23,7 @@ const allTags = [...new Set(
       <!-- Header -->
       <div class="blog-header" data-animate>
         <div class="blog-header-inner">
-          <span class="inline-flex items-center gap-2 text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
-            <span class="inline-block w-6 h-[2px] bg-[var(--accent)]"></span>
+          <span class="inline-flex items-center text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
             Blog
           </span>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -13,8 +13,7 @@ import FloatingShapes from '@/components/astro/FloatingShapes.astro';
       <div class="contact-grid">
         <!-- Left: Header + personality -->
         <div class="contact-intro" data-animate>
-          <span class="inline-flex items-center gap-2 text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-6">
-            <span class="inline-block w-6 h-[2px] bg-[var(--accent)]"></span>
+          <span class="inline-flex items-center text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
             Contact
           </span>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const articles = data.allArticles?.slice(0, 3) ?? [];
             <span class="sh-highlight">selected</span> work<span class="sh-dot">.</span>
           </span>
         </h2>
-        <span class="sh-count">{String(projects.length).padStart(2, '0')} projects</span>
+        <span class="sh-count">{projects.length} projects</span>
       </div>
     </Container>
     <ProjectShowcase projects={projects} />

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -23,8 +23,7 @@ const cameras = [...new Set(places.map((p: any) => p.camera).filter(Boolean))];
     <!-- Hero header -->
     <div class="photos-header" data-animate>
       <div class="photos-header-inner">
-        <span class="inline-flex items-center gap-2 text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
-          <span class="inline-block w-6 h-[2px] bg-[var(--accent)]"></span>
+        <span class="inline-flex items-center text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
           Gallery
         </span>
 
@@ -80,7 +79,7 @@ const cameras = [...new Set(places.map((p: any) => p.camera).filter(Boolean))];
   .photos-header {
     position: relative;
     z-index: 1;
-    padding: 1rem 0 2.5rem;
+    padding: 2rem 0 2.5rem;
   }
 
   .photos-header-inner {

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -21,8 +21,7 @@ const allTags = [...new Set(
     <Container>
       <div class="work-hero" data-animate>
         <div class="work-hero-inner">
-          <span class="inline-flex items-center gap-2 text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
-            <span class="inline-block w-6 h-[2px] bg-[var(--accent)]"></span>
+          <span class="inline-flex items-center text-sm font-body font-medium text-[var(--accent)] tracking-wide uppercase mb-5">
             Portfolio
           </span>
 
@@ -61,7 +60,6 @@ const allTags = [...new Set(
       const img = project.thumbnail?.responsiveImage;
       const tagList = project.tags ? project.tags.split(/[,·]/).map((t: string) => t.trim()).filter(Boolean) : [];
       const href = `/work/${project.slug}`;
-      const indexLabel = String(i + 1).padStart(2, '0');
       const isEven = i % 2 === 1;
       const year = project.date ? new Date(project.date as string).getFullYear().toString() : '';
 
@@ -95,7 +93,6 @@ const allTags = [...new Set(
 
               {/* Info side */}
               <div class="work-project-info">
-                <span class="work-project-num" aria-hidden="true">{indexLabel}</span>
                 <h2 class="work-project-title">{project.title}</h2>
                 {tagList.length > 0 && (
                   <div class="work-project-tags">
@@ -314,25 +311,6 @@ const allTags = [...new Set(
     gap: 0;
   }
 
-  .work-project-num {
-    font-family: 'Bricolage Grotesque', Georgia, serif;
-    font-size: clamp(4rem, 8vw, 6.5rem);
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: -0.04em;
-    color: var(--border);
-    transition: color 0.4s ease;
-    margin-bottom: 0.75rem;
-  }
-
-  .work-project:hover .work-project-num {
-    color: var(--accent-glow-strong);
-  }
-
-  [data-theme="light"] .work-project:hover .work-project-num {
-    color: color-mix(in srgb, var(--accent) 20%, transparent);
-  }
-
   .work-project-title {
     font-family: 'Bricolage Grotesque', Georgia, serif;
     font-size: clamp(1.5rem, 3vw, 2.25rem);
@@ -439,10 +417,6 @@ const allTags = [...new Set(
       gap: 1.25rem;
     }
 
-    .work-project-num {
-      font-size: 3rem;
-      margin-bottom: 0.25rem;
-    }
   }
 
   /* ===== TOUCH ===== */
@@ -457,10 +431,6 @@ const allTags = [...new Set(
 
     .work-project:hover .work-project-title {
       color: var(--text);
-    }
-
-    .work-project:hover .work-project-num {
-      color: var(--border);
     }
 
     .work-project:active {
@@ -489,7 +459,6 @@ const allTags = [...new Set(
     .work-project-img,
     .work-project-accent,
     .work-project-cta-arrow,
-    .work-project-num,
     .work-project-title,
     .work-project-tag,
     .work-project-cta,

--- a/src/scripts/easter-eggs.ts
+++ b/src/scripts/easter-eggs.ts
@@ -95,7 +95,7 @@ function showToast(message: string) {
 function printConsoleMessage() {
   console.log(
     '%c👋 Hey there, curious developer!',
-    'font-size: 18px; font-weight: bold; color: #f97316; padding: 8px 0;',
+    'font-size: 18px; font-weight: bold; color: #ff6600; padding: 8px 0;',
   )
   console.log(
     '%cPeeking under the hood? Nice. Try the Konami Code... ↑↑↓↓←→←→BA',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,24 +3,26 @@
 
 /* ===== DESIGN TOKENS ===== */
 :root {
-  /* Core palette — dark zinc */
-  --bg: #09090b;
-  --bg-elevated: #131316;
-  --bg-surface: #1a1a1f;
-  --border: #27272a;
-  --border-hover: #52525b;
+  /* Core palette — KTM gunmetal (cool anthracite, lifted off pure black) */
+  --bg: #0f1113;
+  --bg-elevated: #16191c;
+  --bg-surface: #1c2024;
+  --border: #292e33;
+  --border-hover: #4c535a;
 
   /* Text */
   --text: #fafafa;
   --text-secondary: #a1a1aa;
   --text-muted: #71717a;
 
-  /* Accent — warm orange */
-  --accent: #f97316;
-  --accent-hover: #fb923c;
-  --accent-muted: #c2410c;
-  --accent-glow: rgba(249, 115, 22, 0.10);
-  --accent-glow-strong: rgba(249, 115, 22, 0.20);
+  /* Accent — KTM racing orange */
+  --accent: #ff6600;
+  --accent-hover: #ff8534;
+  --accent-muted: #cc4a00;
+  /* Raw accent channels for decorative glows at arbitrary alphas */
+  --accent-glow-rgb: 255, 102, 0;
+  --accent-glow: rgba(var(--accent-glow-rgb), 0.10);
+  --accent-glow-strong: rgba(var(--accent-glow-rgb), 0.20);
 
   /* Legacy compat tokens used by React components */
   --foreground: var(--text);
@@ -31,7 +33,7 @@
   --primary-foreground: var(--bg);
 
   /* Gradient */
-  --gradient-accent: linear-gradient(135deg, #f97316 0%, #ea580c 50%, #dc2626 100%);
+  --gradient-accent: linear-gradient(135deg, #ff7a1a 0%, #ff6600 50%, #e14000 100%);
   --gradient-surface: linear-gradient(145deg, var(--bg-elevated) 0%, var(--bg) 100%);
 
   /* Radii */
@@ -43,8 +45,7 @@
   --destructive: #ef4444;
 
   /* Navbar */
-  --nav-bg: rgba(9, 9, 11, 0.90);
-  --nav-border: rgba(255, 255, 255, 0.04);
+  --nav-bg: rgba(15, 17, 19, 0.90);
   --nav-active-bg: rgba(255, 255, 255, 0.06);
   --nav-hover-bg: rgba(255, 255, 255, 0.04);
 
@@ -67,19 +68,18 @@
   --text-secondary: #52525b;
   --text-muted: #71717a;
 
-  --accent: #ea580c;
-  --accent-hover: #c2410c;
-  --accent-muted: #fb923c;
-  --accent-glow: rgba(234, 88, 12, 0.14);
-  --accent-glow-strong: rgba(234, 88, 12, 0.25);
+  --accent: #e85400;
+  --accent-hover: #c44700;
+  --accent-muted: #ff8534;
+  --accent-glow: rgba(232, 84, 0, 0.14);
+  --accent-glow-strong: rgba(232, 84, 0, 0.25);
 
-  --gradient-accent: linear-gradient(135deg, #f97316 0%, #ea580c 50%, #dc2626 100%);
+  --gradient-accent: linear-gradient(135deg, #ff7a1a 0%, #ff6600 50%, #e14000 100%);
   --gradient-surface: linear-gradient(145deg, var(--bg-elevated) 0%, var(--bg) 100%);
 
   --destructive: #dc2626;
 
   --nav-bg: rgba(250, 250, 250, 0.90);
-  --nav-border: rgba(0, 0, 0, 0.06);
   --nav-active-bg: rgba(0, 0, 0, 0.05);
   --nav-hover-bg: rgba(0, 0, 0, 0.03);
 
@@ -580,7 +580,7 @@ a {
 }
 
 .orb-orange {
-  background: radial-gradient(circle, rgba(249, 115, 22, 0.10) 0%, rgba(249, 115, 22, 0.04) 40%, transparent 70%);
+  background: radial-gradient(circle, rgba(var(--accent-glow-rgb), 0.10) 0%, rgba(var(--accent-glow-rgb), 0.04) 40%, transparent 70%);
 }
 
 .orb-blue {
@@ -588,7 +588,7 @@ a {
 }
 
 [data-theme="light"] .orb-orange {
-  background: radial-gradient(circle, rgba(249, 115, 22, 0.15) 0%, rgba(249, 115, 22, 0.06) 40%, transparent 70%);
+  background: radial-gradient(circle, rgba(var(--accent-glow-rgb), 0.15) 0%, rgba(var(--accent-glow-rgb), 0.06) 40%, transparent 70%);
 }
 
 [data-theme="light"] .orb-blue {


### PR DESCRIPTION
A design pass to reduce the "AI-generated" read of the site, plus the cleanup findings from `/simplify`.

## Design changes
- **Palette** — swapped the default zinc + `orange-500` tokens for **KTM racing orange** (`#ff6600`) on a cool **gunmetal** ground. The navbar background now matches the rest of the dark theme. Decorative glow channels are tokenized as `--accent-glow-rgb` so a future palette swap is one line.
- **Eyebrows** — removed the leading accent dash from the shared `Eyebrow` component and the four one-off inline eyebrows (contact/blog/photos/work), and aligned the page-header eyebrows to the same top offset.
- **Numbered markers** — removed the decorative `01/02/03` from `Card`, `ProjectShowcase`, the work index, and about's practice columns.
- **Navbar** — dropped the always-on bar. It's transparent at the hero top (so the page's ambient light blends through with no seam) and fades in a blurred bar only once scrolled; the `backdrop-filter` blur is gated on the scrolled state so no surface is composited while invisible.
- **Copy** — dropped a few em-dash splices and reworked some lines into a plainer first-person voice.

## Cleanup (`/simplify`)
- Removed the now-dead `index` prop on `Card` and its caller in `CardGrid`.
- Removed the unused `--nav-border` token (both themes).
- Stripped inert flex styling from a single-child `.practice-col-head` wrapper.
- Fixed a stale hardcoded `#f97316` in the console greeting.

**Skipped (intentional):** consolidating the four inline eyebrows onto the shared `<Eyebrow>` component — it renders at a different size/weight/tracking, so it would restyle those page headers. Worth doing as a deliberate design decision, not a silent cleanup.

Verified: `astro check` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)